### PR TITLE
Updating to reflect name change of the puppetdb-terminus package to puppetdb-termini

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -129,7 +129,7 @@ String.  Source for hiera.yaml to install.  Will enable hiera lookups on the ser
 Default: undef
 
 #####`server_puppetdb`
-Boolean.  Whether or not puppetdb terminus and route configuration should be installed
+Boolean.  Whether or not puppetdb termini and route configuration should be installed
 
 Default: false
 
@@ -144,7 +144,7 @@ String.  Hostname where puppetdb is running.  Required if puppetdb => true
 Default: undef
 
 #####`server_puppetdb_version`
-String.  Version of puppetdb-terminus to install.
+String.  Version of puppetdb-termini to install.
 
 Default: latest
 

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -24,7 +24,7 @@ class puppet::server::install (
     ensure => $_server_version,
   }
 
-  package { 'puppetdb-terminus':
+  package { 'puppetdb-termini':
     ensure => $_puppetdb_version,
   }
 

--- a/spec/classes/puppet_server_install_spec.rb
+++ b/spec/classes/puppet_server_install_spec.rb
@@ -17,23 +17,23 @@ describe 'puppet::server::install', :type => :class do
   describe 'server == false' do
     let(:pre_condition) { 'class {"::puppet": server => false }' }
     it { should contain_package('puppetserver').with(:ensure => 'absent') }
-    it { should contain_package('puppetdb-terminus').with(:ensure => 'absent') }
+    it { should contain_package('puppetdb-termini').with(:ensure => 'absent') }
   end
 
   describe 'puppetdb' do
     context 'default' do
       let(:pre_condition) { 'class {"::puppet": server => true}' }
-      it { should contain_package('puppetdb-terminus').with(:ensure => 'absent') }
+      it { should contain_package('puppetdb-termini').with(:ensure => 'absent') }
     end
 
     context 'installed' do
       let(:pre_condition) { 'class {"::puppet": server => true, puppetdb => true, puppetdb_server => "db.example.com"}' }
-      it { should contain_package('puppetdb-terminus').with(:ensure => 'latest') }
+      it { should contain_package('puppetdb-termini').with(:ensure => 'latest') }
     end
 
     context 'with version' do
       let(:pre_condition) { 'class {"::puppet": server => true, puppetdb => true, puppetdb_server => "db.example.com", puppetdb_version => "2.2.3"}' }
-      it { should contain_package('puppetdb-terminus').with(:ensure => '2.2.3') }
+      it { should contain_package('puppetdb-termini').with(:ensure => '2.2.3') }
     end
   end
 


### PR DESCRIPTION
As of puppetdb v3.0 the puppetdb-terminus package was renamed to puppetdb-termini. 