### PR TITLE
Exposed ability to set number of jruby instances and set a sane default.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,6 +128,13 @@ String.  Source for hiera.yaml to install.  Will enable hiera lookups on the ser
 
 Default: undef
 
+#####`jruby_instances`
+Integer.  Number of JRuby instances to start up inside the puppetserver JVM
+
+Default: $::processors[count]-1
+
+Note: if this value is not >= 1, then this is defaulted to 1.
+
 #####`server_puppetdb`
 Boolean.  Whether or not puppetdb termini and route configuration should be installed
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class puppet (
   Optional[Array[String]]                      $server_reports    = $::puppet::params::server_reports,
   String                                       $server_version    = $::puppet::params::server_version,
   Boolean                                      $firewall          = $::puppet::params::firewall,
+  Integer                                      $jruby_instances   = $::puppet::params::jruby_instances,
 ) inherits puppet::params {
 
   if $puppetdb and !$puppetdb_server {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class puppet::params {
   $server_reports = undef
   $server_version = 'latest'
   $firewall = false
+  $jruby_instances = $::processors[count]-1
 
   case $::osfamily {
     'Debian': {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -14,6 +14,7 @@ class puppet::server::config (
   $puppetdb_server = $::puppet::puppetdb_server,
   $reports         = $::puppet::server_reports,
   $firewall        = $::puppet::firewall,
+  $jruby_instances = $::puppet::jruby_instances,
 ) {
 
   $file_ensure = $server ? {

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -44,7 +44,7 @@ describe 'puppet::server::config', :type => :class do
       it { should contain_file('/etc/puppetlabs/puppetserver/request-logging.xml') }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/ca.conf') }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/global.conf') }
-      it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf') }
+      it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf').with( :content => /max-active-instances: 3/ ) }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf') }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/webserver.conf') }
       it { should contain_file('/etc/puppetlabs/code/hiera.yaml').with(:ensure => 'absent') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,11 @@
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+  # Set default project facts here
+  c.default_facts = {
+    :processors => {
+      'count' => 4
+    }
+  }
+end

--- a/templates/server/puppetserver.conf.erb
+++ b/templates/server/puppetserver.conf.erb
@@ -26,7 +26,7 @@ jruby-puppet: {
     master-log-dir: /var/log/puppetlabs/puppetserver
 
     # (optional) maximum number of JRuby instances to allow
-    # max-active-instances: 1
+    max-active-instances: <%= if @jruby_instances > 0 then @jruby_instances else 1 end %>
 }
 
 # settings related to HTTP client requests made by Puppet Server


### PR DESCRIPTION
This sets the default to a sane value that's sized to the machine your running this on.  But this can be overwritten if required..

Puppetlabs documentation here: https://docs.puppetlabs.com/puppetserver/latest/configuration.html#puppetserverconf

*Defaults to ‘num-cpus - 1’, with a minimum default value of 1 and a maximum default value of 4.*