### PR TITLE
Disable the puppetserver report processor feature by default

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -183,7 +183,7 @@ Default:  puppetserver.log
 #####`server_reports`
 Array[String].  List of reports to enable
 
-Default: undef
+Default: ['none']
 
 #####`server_version`
 String.  Version of puppetserver to install.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class puppet::params {
   $server_java_opts = '-Xms2g -Xmx2g -XX:MaxPermSize=256m'
   $server_log_dir = '/var/log/puppetlabs/puppetserver'
   $server_log_file = 'puppetserver.log'
-  $server_reports = undef
+  $server_reports = ['none']
   $server_version = 'latest'
   $firewall = false
   $jruby_instances = $::processors[count]-1

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -35,7 +35,7 @@ describe 'puppet::server::config', :type => :class do
 
       it { should contain_file('/var/log/puppetlabs/puppetserver').with(:ensure => 'directory') }
       it { should contain_concat__fragment('puppet_master').with(:content => /ca = true/) }
-      it { should_not contain_concat__fragment('puppet_master').with(:content => /reports/) }
+      it { should contain_concat__fragment('puppet_master').with(:content => /reports = none/) }
       it { should_not contain_concat__fragment('puppet_master').with( :content => /dns_alt_names/ ) }
       it { should_not contain_concat__fragment('puppet_master').with(:content => /storeconfigs/) }
       it { should contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-service\/certificate\-authority\-service/) }


### PR DESCRIPTION
By default if reports is NOT defined, puppetserver will enable the "store" reports processor which will generate yaml reports in: /opt/puppetlabs/server/data/puppetserver/reports/
See: https://docs.puppetlabs.com/puppet/latest/reference/reporting_about.html#configuring-reporting

If your not expecting this or dealing with this some way, you will probably run your puppetserver out of disk space.  This PR defaults this to "none" which will turn this feature off.