### PR TITLE
(GH41) When puppetdb is false, do not manage puppetdb at all

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -140,22 +140,22 @@ Default: $::processors[count]-1
 
 Note: if this value is not >= 1, then this is defaulted to 1.
 
-#####`server_puppetdb`
+#####`puppetdb`
 Boolean.  Whether or not puppetdb termini and route configuration should be installed
 
 Default: false
 
-#####`server_puppetdb_port`
+#####`puppetdb_port`
 Integer.  Port puppetdb is listening on.
 
 Default: 8081
 
-#####`server_puppetdb_server`
+#####`puppetdb_server`
 String.  Hostname where puppetdb is running.  Required if puppetdb => true
 
 Default: undef
 
-#####`server_puppetdb_version`
+#####`puppetdb_version`
 String.  Version of puppetdb-termini to install.
 
 Default: latest

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -24,8 +24,10 @@ class puppet::server::install (
     ensure => $_server_version,
   }
 
-  package { 'puppetdb-termini':
-    ensure => $_puppetdb_version,
+  if $puppetdb {
+    package { 'puppetdb-termini':
+      ensure => $_puppetdb_version,
+    }
   }
 
   # Set up environments

--- a/spec/classes/puppet_server_install_spec.rb
+++ b/spec/classes/puppet_server_install_spec.rb
@@ -17,13 +17,13 @@ describe 'puppet::server::install', :type => :class do
   describe 'server == false' do
     let(:pre_condition) { 'class {"::puppet": server => false }' }
     it { should contain_package('puppetserver').with(:ensure => 'absent') }
-    it { should contain_package('puppetdb-termini').with(:ensure => 'absent') }
+    it { should_not contain_package('puppetdb-termini') }
   end
 
   describe 'puppetdb' do
     context 'default' do
       let(:pre_condition) { 'class {"::puppet": server => true}' }
-      it { should contain_package('puppetdb-termini').with(:ensure => 'absent') }
+      it { should_not contain_package('puppetdb-termini') }
     end
 
     context 'installed' do


### PR DESCRIPTION
  Update README.markdown with the proper puppetdb-related variable names.
  If puppetdb is false, do not manage puppetdb-termini.
  Update rspec tests.