### PR TITLE
Manage puppetdb

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@ class puppet (
   Integer                                      $puppetdb_port     = $::puppet::params::puppetdb_port,
   Optional[String]                             $puppetdb_server   = $::puppet::params::puppetdb_server,
   String                                       $puppetdb_version  = $::puppet::params::puppetdb_version,
+  Boolean                                      $manage_termini    = $::puppet::params::manage_termini,
   String                                       $runinterval       = $::puppet::params::runinterval,
   Boolean                                      $server_ca_enabled = $::puppet::params::server_ca_enabled,
   Optional[String]                             $server_certname   = $::puppet::params::server_certname,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class puppet (
   Integer                                      $puppetdb_port     = $::puppet::params::puppetdb_port,
   Optional[String]                             $puppetdb_server   = $::puppet::params::puppetdb_server,
   String                                       $puppetdb_version  = $::puppet::params::puppetdb_version,
-  Boolean                                      $manage_termini    = $::puppet::params::manage_termini,
+  Boolean                                      $manage_puppetdb   = $::puppet::params::manage_puppetdb,
   String                                       $runinterval       = $::puppet::params::runinterval,
   Boolean                                      $server_ca_enabled = $::puppet::params::server_ca_enabled,
   Optional[String]                             $server_certname   = $::puppet::params::server_certname,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class puppet::params {
   $puppetdb_port = 8081
   $puppetdb_server = undef
   $puppetdb_version = 'latest'
-  $manage_termini = true
+  $manage_puppetdb = true
   $runinterval = '30m'
   $server_ca_enabled = true
   $server_certname = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class puppet::params {
   $puppetdb_port = 8081
   $puppetdb_server = undef
   $puppetdb_version = 'latest'
+  $manage_termini = true
   $runinterval = '30m'
   $server_ca_enabled = true
   $server_certname = undef

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -14,6 +14,7 @@ class puppet::server::config (
   $puppetdb        = $::puppet::puppetdb,
   $puppetdb_port   = $::puppet::puppetdb_port,
   $puppetdb_server = $::puppet::puppetdb_server,
+  $manage_puppetdb = $::puppet::manage_puppetdb,
   $reports         = $::puppet::server_reports,
   $firewall        = $::puppet::firewall,
   $jruby_instances = $::puppet::jruby_instances,
@@ -109,7 +110,7 @@ class puppet::server::config (
     }
   }
 
-  if ( $server and $puppetdb) {
+  if ( $server and $puppetdb and $manage_puppetdb) {
     file { '/etc/puppetlabs/puppet/routes.yaml':
       source => 'puppet:///modules/puppet/routes.yaml',
     }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -2,7 +2,7 @@
 class puppet::server::install (
   $puppetdb         = $::puppet::puppetdb,
   $puppetdb_version = $::puppet::puppetdb_version,
-  $manage_termini   = $::puppet::manage_termini,
+  $manage_puppetdb  = $::puppet::manage_puppetdb,
   $server           = $::puppet::server,
   $server_version   = $::puppet::server_version,
 ) {
@@ -25,7 +25,7 @@ class puppet::server::install (
     ensure => $_server_version,
   }
 
-  if ($server and $puppetdb and $manage_termini) {
+  if ($server and $puppetdb and $manage_puppetdb) {
     package { 'puppetdb-termini':
       ensure => $_puppetdb_version,
     }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -2,6 +2,7 @@
 class puppet::server::install (
   $puppetdb         = $::puppet::puppetdb,
   $puppetdb_version = $::puppet::puppetdb_version,
+  $manage_termini   = $::puppet::manage_termini,
   $server           = $::puppet::server,
   $server_version   = $::puppet::server_version,
 ) {
@@ -24,7 +25,7 @@ class puppet::server::install (
     ensure => $_server_version,
   }
 
-  if $puppetdb {
+  if ($server and $puppetdb and $manage_termini) {
     package { 'puppetdb-termini':
       ensure => $_puppetdb_version,
     }

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -92,6 +92,13 @@ describe 'puppet::server::config', :type => :class do
       it { should contain_concat__fragment('puppet_master').with(:content => /storeconfigs/) }
     end
 
+    context 'with puppetdb but without managed puppetdb' do
+      let(:pre_condition) { 'class { "puppet": server => true, puppetdb => true, puppetdb_server => "db.example.com", manage_puppetdb => false}'}
+      it { should_not contain_file('/etc/puppetlabs/puppet/routes.yaml') }
+      it { should_not contain_file('/etc/puppetlabs/puppet/puppetdb.conf').with(:content => /db\.example\.com/) }
+      it { should contain_concat__fragment('puppet_master').with(:content => /storeconfigs/) }
+    end
+
     context 'with reports' do
       let(:pre_condition) { 'class { "puppet": server => true, server_reports => ["puppetdb", "hipchat"] }'}
       it { should contain_concat__fragment('puppet_master').with(:content => /reports = puppetdb, hipchat/) }

--- a/spec/classes/puppet_server_install_spec.rb
+++ b/spec/classes/puppet_server_install_spec.rb
@@ -37,7 +37,7 @@ describe 'puppet::server::install', :type => :class do
     end
 
     context 'without termini' do
-      let(:pre_condition) { 'class {"::puppet": server => true, puppetdb => true, puppetdb_server => "db.example.com", puppetdb_version => "2.2.3", manage_termini => false}' }
+      let(:pre_condition) { 'class {"::puppet": server => true, puppetdb => true, puppetdb_server => "db.example.com", puppetdb_version => "2.2.3", manage_puppetdb => false}' }
       it { should_not contain_package('puppetdb-termini') }
     end
   end

--- a/spec/classes/puppet_server_install_spec.rb
+++ b/spec/classes/puppet_server_install_spec.rb
@@ -35,6 +35,11 @@ describe 'puppet::server::install', :type => :class do
       let(:pre_condition) { 'class {"::puppet": server => true, puppetdb => true, puppetdb_server => "db.example.com", puppetdb_version => "2.2.3"}' }
       it { should contain_package('puppetdb-termini').with(:ensure => '2.2.3') }
     end
+
+    context 'without termini' do
+      let(:pre_condition) { 'class {"::puppet": server => true, puppetdb => true, puppetdb_server => "db.example.com", puppetdb_version => "2.2.3", manage_termini => false}' }
+      it { should_not contain_package('puppetdb-termini') }
+    end
   end
 
 end


### PR DESCRIPTION
In PR #41 I worked I identified that the termini package could have overlap with other modules. I have identified other aspects that overlap with `puppetlabs/puppetdb` and added the parameter `$manage_puppetdb` to disable the overlapping resources.